### PR TITLE
Avoid iterating data.getFellowPlayers() when null

### DIFF
--- a/src/com/robrua/orianna/type/core/game/Game.java
+++ b/src/com/robrua/orianna/type/core/game/Game.java
@@ -75,6 +75,10 @@ public class Game extends OriannaObject<com.robrua.orianna.type.dto.game.Game> {
      */
     public List<Player> getFellowPlayers() {
         if(fellowPlayers == null) {
+            if(data.getFellowPlayers() == null) {
+                return Collections.emptyList();
+            }
+            
             fellowPlayers = new ArrayList<>();
             for(final com.robrua.orianna.type.dto.game.Player player : data.getFellowPlayers()) {
                 fellowPlayers.add(new Player(player));


### PR DESCRIPTION
Iterating over data.getFellowPlayers() fail when the game is a custom game with no other players: fellowPlayers and data.getFellowPlayers() are both null