### PR TITLE
Avoid iterating roster.getMemberList() when null

### DIFF
--- a/src/com/robrua/orianna/type/dto/team/Team.java
+++ b/src/com/robrua/orianna/type/dto/team/Team.java
@@ -152,8 +152,11 @@ public class Team extends OriannaDto {
     public Set<Long> getSummonerIDs() {
         final Set<Long> set = new HashSet<>();
         set.add(roster.getOwnerId());
-        for(final TeamMemberInfo member : roster.getMemberList()) {
-            set.add(member.getPlayerId());
+        
+        if(roster.getMemberList() != null) {
+            for(final TeamMemberInfo member : roster.getMemberList()) {
+               set.add(member.getPlayerId());
+            }
         }
 
         return set;


### PR DESCRIPTION
This case happens with: RiotAPI.getTeam("TEAM-cf4ac0f0-c7bc-11e5-b946-c81f66dd32cd");