### PR TITLE
add missing lane value

### DIFF
--- a/orianna/src/main/java/com/merakianalytics/orianna/types/common/Lane.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/types/common/Lane.java
@@ -6,5 +6,6 @@ public enum Lane {
         JUNGLE,
         MID,
         MIDDLE,
-        TOP;
+        TOP,
+        NONE;
 }


### PR DESCRIPTION
Current `Lane` enum is missing NONE value. 

Example: https://imgur.com/a/tAvsLN8