### PR TITLE
Add Riot Account support (using Riot Account-V1)

### DIFF
--- a/orianna/src/main/java/com/merakianalytics/orianna/Orianna.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/Orianna.java
@@ -8,6 +8,9 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+import com.merakianalytics.orianna.datapipeline.transformers.dtodata.AccountTransformer;
+import com.merakianalytics.orianna.types.core.account.Account;
+import com.merakianalytics.orianna.types.core.account.Accounts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,6 +108,7 @@ public abstract class Orianna {
             final PipelineConfiguration config = new PipelineConfiguration();
 
             final Set<TransformerConfiguration> transformers = ImmutableSet.of(
+                TransformerConfiguration.defaultConfiguration(AccountTransformer.class),
                 TransformerConfiguration.defaultConfiguration(ChampionMasteryTransformer.class),
                 TransformerConfiguration.defaultConfiguration(ChampionTransformer.class),
                 TransformerConfiguration.defaultConfiguration(LeagueTransformer.class),
@@ -1022,6 +1026,18 @@ public abstract class Orianna {
 
     public static ShardStatus.Builder shardStatusWithRegion(final Region region) {
         return ShardStatus.withRegion(region);
+    }
+
+    public static Account.Builder accountWithPuuid(final String puuid) { return Account.withPuuid(puuid); }
+
+    public static Account.Builder accountWithRiotId(final String gameName, final String tagLine) {
+        return Account.withRiotId(gameName, tagLine);
+    }
+
+    public static Accounts.Builder accountsWithPuuids(final String... puuids) { return Accounts.withPuuids(puuids); }
+
+    public static Accounts.Builder accountsWithRiotIds(final List<java.util.Map.Entry<String, String>> riotIds) {
+        return Accounts.withRiotIds(riotIds);
     }
 
     public static Summoner.Builder summonerNamed(final String name) {

--- a/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/InMemoryCache.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/InMemoryCache.java
@@ -1731,7 +1731,7 @@ public class InMemoryCache extends AbstractDataStore {
     public void putAccount(final Account account, final PipelineContext context) {
         final int[] keys = UniqueKeys.forAccount(account);
 
-        if (keys.length > 1) {
+        if (keys.length < 3) {
             final LoadHook hook = new LoadHook() {
                 @Override
                 public void call() {

--- a/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/data/AccountAPI.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/data/AccountAPI.java
@@ -1,0 +1,117 @@
+package com.merakianalytics.orianna.datapipeline.kernel.data;
+
+import com.google.common.collect.ImmutableMap;
+import com.merakianalytics.datapipelines.PipelineContext;
+import com.merakianalytics.datapipelines.iterators.CloseableIterator;
+import com.merakianalytics.datapipelines.iterators.CloseableIterators;
+import com.merakianalytics.datapipelines.sources.Get;
+import com.merakianalytics.datapipelines.sources.GetMany;
+import com.merakianalytics.orianna.datapipeline.common.HTTPClient;
+import com.merakianalytics.orianna.datapipeline.common.Utilities;
+import com.merakianalytics.orianna.types.common.Platform;
+import com.merakianalytics.orianna.types.data.account.Account;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class AccountAPI extends KernelService {
+    public AccountAPI(Kernel.Configuration config, HTTPClient client) {
+        super(config, client);
+    }
+
+    @SuppressWarnings("unchecked")
+    @GetMany(Account.class)
+    public CloseableIterator<Account> getManyAccount(final Map<String, Object> query, final PipelineContext context) {
+        final Platform platform = (Platform) query.get("platform");
+        Utilities.checkNotNull(platform, "platform");
+        final Iterable<String> puuids = (Iterable<String>)query.get("puuids");
+        final Iterable<Map.Entry<String, String>> riotIds = (Iterable<Map.Entry<String, String>>)query.get("riotIds");
+        Utilities.checkAtLeastOneNotNull(puuids, "puuids", riotIds, "riotIds");
+
+        final Iterator<String> puuidsIterator;
+        final Iterator<Map.Entry<String, String>> riotIdsIterator;
+        final String baseEndpoint;
+
+        if (puuids != null) {
+            puuidsIterator = puuids.iterator();
+            riotIdsIterator = null;
+            baseEndpoint = "riot/account/v1/accounts/by-puuid/";
+        }
+        else if (riotIds != null) {
+            puuidsIterator = null;
+            riotIdsIterator = riotIds.iterator();
+            baseEndpoint = "/riot/account/v1/accounts/by-riot-id/";
+        }
+        else {
+            return null;
+        }
+
+        return CloseableIterators.from(new Iterator<Account>() {
+            @Override
+            public boolean hasNext() {
+                if (puuidsIterator != null) {
+                    return puuidsIterator.hasNext();
+                }
+                return riotIdsIterator.hasNext();
+            }
+
+            @Override
+            public Account next() {
+                if (puuidsIterator != null) {
+                    final String identifier = puuidsIterator.next();
+                    final String endpoint = baseEndpoint + identifier;
+                    final Account data = get(Account.class, endpoint, ImmutableMap.of("platform", platform.getTag()), true);
+
+                    if (data == null) {
+                        return null;
+                    }
+                    return data;
+                }
+                else {
+                    final Map.Entry<String, String> identifier = riotIdsIterator.next();
+                    final String endpoint = baseEndpoint + identifier.getKey() + "/" + identifier.getValue();
+                    final Account data = get(Account.class, endpoint, ImmutableMap.of("platform", platform.getTag()), true);
+                    if (data == null) {
+                        return null;
+                    }
+
+                    return data;
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        });
+    }
+
+    @Get(Account.class)
+    public Account getAccount(final Map<String, Object> query, final PipelineContext context) {
+        final Platform platform = (Platform) query.get("platform");
+        Utilities.checkNotNull(platform, "platform");
+        final String puuid = (String)query.get("puuid");
+        final String gameName = (String)query.get("gameName");
+        final String tagLine = (String)query.get("tagLine");
+        Utilities.checkAtLeastOneNotNull(puuid, "puuid", gameName, "gameName", tagLine, "tagLine");
+
+        System.out.println("data " + puuid + gameName + tagLine);
+        String endpoint;
+        if (puuid != null) {
+            endpoint = "riot/account/v1/accounts/by-puuid/" + puuid;
+        }
+        else if (gameName != null && tagLine != null) {
+            endpoint = "riot/account/v1/accounts/by-riot-id/" + gameName + "/" + tagLine;
+        }
+        else {
+            return null;
+        }
+
+        final Account data = get(Account.class, endpoint, ImmutableMap.of("platform", platform.getTag()), true);
+        if (data == null) {
+            return null;
+        }
+
+        return data;
+    }
+}

--- a/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/data/AccountAPI.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/data/AccountAPI.java
@@ -95,7 +95,6 @@ public class AccountAPI extends KernelService {
         final String tagLine = (String)query.get("tagLine");
         Utilities.checkAtLeastOneNotNull(puuid, "puuid", gameName, "gameName", tagLine, "tagLine");
 
-        System.out.println("data " + puuid + gameName + tagLine);
         String endpoint;
         if (puuid != null) {
             endpoint = "riot/account/v1/accounts/by-puuid/" + puuid;

--- a/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/data/Kernel.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/data/Kernel.java
@@ -24,7 +24,7 @@ public class Kernel extends CompositeDataSource {
         private static final boolean DEFAULT_MSGPACK = true;
         private static final int DEFAULT_PORT = 80;
         private static final HTTPClient.Configuration DEFAULT_REQUESTS = new HTTPClient.Configuration();
-        private static final Set<Class<? extends KernelService>> DEFAULT_SERVICES = ImmutableSet.of(ChampionAPI.class, ChampionMasteryAPI.class,
+        private static final Set<Class<? extends KernelService>> DEFAULT_SERVICES = ImmutableSet.of(AccountAPI.class, ChampionAPI.class, ChampionMasteryAPI.class,
             LeagueAPI.class, MatchAPI.class, SpectatorAPI.class, StatusAPI.class, SummonerAPI.class, ThirdPartyCodeAPI.class);
 
         private String host = DEFAULT_HOST;

--- a/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/data/KernelService.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/data/KernelService.java
@@ -400,12 +400,21 @@ public class KernelService extends AbstractDataSource {
         public String endpoint;
         public Multimap<String, String> parameters;
         public Class<T> type;
+        public boolean isRegionalRequest;
 
         public RequestContext(final Class<T> type, final String endpoint, final Multimap<String, String> parameters) {
             this.type = type;
             this.endpoint = endpoint;
             this.parameters = parameters;
             this.attemptCount = 1;
+            this.isRegionalRequest = false;
+        }
+        public RequestContext(final Class<T> type, final String endpoint, final Multimap<String, String> parameters, final boolean isRegionalRequest) {
+            this.type = type;
+            this.endpoint = endpoint;
+            this.parameters = parameters;
+            this.attemptCount = 1;
+            this.isRegionalRequest = isRegionalRequest;
         }
     }
 
@@ -449,6 +458,11 @@ public class KernelService extends AbstractDataSource {
 
     protected <T extends CoreData> T get(final Class<T> type, final String endpoint, final Map<String, String> parameters) {
         final RequestContext<T> context = new RequestContext<>(type, endpoint, parameters == null ? null : ImmutableListMultimap.copyOf(parameters.entrySet()));
+        return get(context);
+    }
+
+    protected <T extends CoreData> T get(final Class<T> type, final String endpoint, final Map<String, String> parameters, final boolean isRegionalRequest) {
+        final RequestContext<T> context = new RequestContext<>(type, endpoint, (parameters == null ? null : ImmutableListMultimap.copyOf(parameters.entrySet())), isRegionalRequest);
         return get(context);
     }
 

--- a/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/dto/AccountAPI.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/dto/AccountAPI.java
@@ -95,7 +95,6 @@ public class AccountAPI extends KernelService {
         final String tagLine = (String)query.get("tagLine");
         Utilities.checkAtLeastOneNotNull(puuid, "puuid", gameName, "gameName", tagLine, "tagLine");
 
-        System.out.println("dto " + puuid + gameName + tagLine);
         String endpoint;
         if (puuid != null) {
             endpoint = "riot/account/v1/accounts/by-puuid/" + puuid;

--- a/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/dto/AccountAPI.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/dto/AccountAPI.java
@@ -1,0 +1,117 @@
+package com.merakianalytics.orianna.datapipeline.kernel.dto;
+
+import com.google.common.collect.ImmutableMap;
+import com.merakianalytics.datapipelines.PipelineContext;
+import com.merakianalytics.datapipelines.iterators.CloseableIterator;
+import com.merakianalytics.datapipelines.iterators.CloseableIterators;
+import com.merakianalytics.datapipelines.sources.Get;
+import com.merakianalytics.datapipelines.sources.GetMany;
+import com.merakianalytics.orianna.datapipeline.common.HTTPClient;
+import com.merakianalytics.orianna.datapipeline.common.Utilities;
+import com.merakianalytics.orianna.types.common.Platform;
+import com.merakianalytics.orianna.types.dto.account.Account;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class AccountAPI extends KernelService {
+    public AccountAPI(Kernel.Configuration config, HTTPClient client) {
+        super(config, client);
+    }
+
+    @SuppressWarnings("unchecked")
+    @GetMany(Account.class)
+    public CloseableIterator<Account> getManyAccount(final Map<String, Object> query, final PipelineContext context) {
+        final Platform platform = (Platform) query.get("platform");
+        Utilities.checkNotNull(platform, "platform");
+        final Iterable<String> puuids = (Iterable<String>)query.get("puuids");
+        final Iterable<Map.Entry<String, String>> riotIds = (Iterable<Map.Entry<String, String>>)query.get("riotIds");
+        Utilities.checkAtLeastOneNotNull(puuids, "puuids", riotIds, "riotIds");
+
+        final Iterator<String> puuidsIterator;
+        final Iterator<Map.Entry<String, String>> riotIdsIterator;
+        final String baseEndpoint;
+
+        if (puuids != null) {
+            puuidsIterator = puuids.iterator();
+            riotIdsIterator = null;
+            baseEndpoint = "riot/account/v1/accounts/by-puuid/";
+        }
+        else if (riotIds != null) {
+            puuidsIterator = null;
+            riotIdsIterator = riotIds.iterator();
+            baseEndpoint = "/riot/account/v1/accounts/by-riot-id/";
+        }
+        else {
+            return null;
+        }
+
+        return CloseableIterators.from(new Iterator<Account>() {
+            @Override
+            public boolean hasNext() {
+                if (puuidsIterator != null) {
+                    return puuidsIterator.hasNext();
+                }
+                return riotIdsIterator.hasNext();
+            }
+
+            @Override
+            public Account next() {
+                if (puuidsIterator != null) {
+                    final String identifier = puuidsIterator.next();
+                    final String endpoint = baseEndpoint + identifier;
+                    final Account data = get(Account.class, endpoint, ImmutableMap.of("platform", platform.getTag()), true);
+
+                    if (data == null) {
+                        return null;
+                    }
+                    return data;
+                }
+                else {
+                    final Map.Entry<String, String> identifier = riotIdsIterator.next();
+                    final String endpoint = baseEndpoint + identifier.getKey() + "/" + identifier.getValue();
+                    final Account data = get(Account.class, endpoint, ImmutableMap.of("platform", platform.getTag()), true);
+                    if (data == null) {
+                        return null;
+                    }
+
+                    return data;
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        });
+    }
+
+    @Get(Account.class)
+    public Account getAccount(final Map<String, Object> query, final PipelineContext context) {
+        final Platform platform = (Platform) query.get("platform");
+        Utilities.checkNotNull(platform, "platform");
+        final String puuid = (String)query.get("puuid");
+        final String gameName = (String)query.get("gameName");
+        final String tagLine = (String)query.get("tagLine");
+        Utilities.checkAtLeastOneNotNull(puuid, "puuid", gameName, "gameName", tagLine, "tagLine");
+
+        System.out.println("dto " + puuid + gameName + tagLine);
+        String endpoint;
+        if (puuid != null) {
+            endpoint = "riot/account/v1/accounts/by-puuid/" + puuid;
+        }
+        else if (gameName != null && tagLine != null) {
+            endpoint = "riot/account/v1/accounts/by-riot-id/" + gameName + "/" + tagLine;
+        }
+        else {
+            return null;
+        }
+
+        final Account data = get(Account.class, endpoint, ImmutableMap.of("platform", platform.getTag()), true);
+        if (data == null) {
+            return null;
+        }
+
+        return data;
+    }
+}

--- a/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/dto/Kernel.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/dto/Kernel.java
@@ -24,8 +24,8 @@ public class Kernel extends CompositeDataSource {
         private static final boolean DEFAULT_MSGPACK = true;
         private static final int DEFAULT_PORT = 80;
         private static final HTTPClient.Configuration DEFAULT_REQUESTS = new HTTPClient.Configuration();
-        private static final Set<Class<? extends KernelService>> DEFAULT_SERVICES = ImmutableSet.of(ChampionAPI.class, ChampionMasteryAPI.class,
-            LeagueAPI.class, MatchAPI.class, SpectatorAPI.class, StatusAPI.class, SummonerAPI.class, ThirdPartyCodeAPI.class);
+        private static final Set<Class<? extends KernelService>> DEFAULT_SERVICES = ImmutableSet.of(AccountAPI.class, ChampionAPI.class,
+                ChampionMasteryAPI.class, LeagueAPI.class, MatchAPI.class, SpectatorAPI.class, StatusAPI.class, SummonerAPI.class, ThirdPartyCodeAPI.class);
 
         private String host = DEFAULT_HOST;
         private FailedRequestStrategy http404Strategy = DEFAULT_404_STRATEGY;

--- a/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/dto/KernelService.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/kernel/dto/KernelService.java
@@ -400,12 +400,21 @@ public class KernelService extends AbstractDataSource {
         public String endpoint;
         public Multimap<String, String> parameters;
         public Class<T> type;
+        public boolean isRegionalRequest;
 
         public RequestContext(final Class<T> type, final String endpoint, final Multimap<String, String> parameters) {
             this.type = type;
             this.endpoint = endpoint;
             this.parameters = parameters;
             this.attemptCount = 1;
+            this.isRegionalRequest = false;
+        }
+        public RequestContext(final Class<T> type, final String endpoint, final Multimap<String, String> parameters, final boolean isRegionalRequest) {
+            this.type = type;
+            this.endpoint = endpoint;
+            this.parameters = parameters;
+            this.attemptCount = 1;
+            this.isRegionalRequest = isRegionalRequest;
         }
     }
 
@@ -449,6 +458,11 @@ public class KernelService extends AbstractDataSource {
 
     protected <T extends DataObject> T get(final Class<T> type, final String endpoint, final Map<String, String> parameters) {
         final RequestContext<T> context = new RequestContext<>(type, endpoint, parameters == null ? null : ImmutableListMultimap.copyOf(parameters.entrySet()));
+        return get(context);
+    }
+
+    protected <T extends DataObject> T get(final Class<T> type, final String endpoint, final Map<String, String> parameters, final boolean isRegionalRequest) {
+        final RequestContext<T> context = new RequestContext<>(type, endpoint, parameters == null ? null : ImmutableListMultimap.copyOf(parameters.entrySet()), isRegionalRequest);
         return get(context);
     }
 

--- a/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/riotapi/AccountAPI.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/riotapi/AccountAPI.java
@@ -1,0 +1,126 @@
+package com.merakianalytics.orianna.datapipeline.riotapi;
+
+import com.merakianalytics.datapipelines.PipelineContext;
+import com.merakianalytics.datapipelines.iterators.CloseableIterator;
+import com.merakianalytics.datapipelines.iterators.CloseableIterators;
+import com.merakianalytics.datapipelines.sources.Get;
+import com.merakianalytics.datapipelines.sources.GetMany;
+import com.merakianalytics.orianna.datapipeline.common.HTTPClient;
+import com.merakianalytics.orianna.datapipeline.common.Utilities;
+import com.merakianalytics.orianna.datapipeline.common.rates.RateLimiter;
+import com.merakianalytics.orianna.types.common.Platform;
+import com.merakianalytics.orianna.types.dto.account.Account;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class AccountAPI extends RiotAPIService {
+    public AccountAPI(final RiotAPI.Configuration config, final HTTPClient client, final Map<Platform, RateLimiter> applicationRateLimiters,
+            final Map<Platform, Object> applicationRateLimiterLocks) {
+        super(config, client, applicationRateLimiters, applicationRateLimiterLocks);
+    }
+
+    @SuppressWarnings("unchecked")
+    @GetMany(Account.class)
+    public CloseableIterator<Account> getManyAccount(final Map<String, Object> query, final PipelineContext context) {
+        final Platform platform = (Platform) query.get("platform");
+        Utilities.checkNotNull(platform, "platform");
+        final Iterable<String> puuids = (Iterable<String>)query.get("puuids");
+        final Iterable<Map.Entry<String, String>> riotIds = (Iterable<Map.Entry<String, String>>)query.get("riotIds");
+        Utilities.checkAtLeastOneNotNull(puuids, "puuids", riotIds, "riotIds");
+
+        final Iterator<String> puuidsIterator;
+        final Iterator<Map.Entry<String, String>> riotIdsIterator;
+        final String baseEndpoint;
+        final String limiter;
+
+        if (puuids != null) {
+            puuidsIterator = puuids.iterator();
+            riotIdsIterator = null;
+            baseEndpoint = "riot/account/v1/accounts/by-puuid/";
+            limiter = "riot/account/v1/accounts/by-puuid/puuid";
+        }
+        else if (riotIds != null) {
+            puuidsIterator = null;
+            riotIdsIterator = riotIds.iterator();
+            baseEndpoint = "/riot/account/v1/accounts/by-riot-id/";
+            limiter = "/riot/account/v1/accounts/by-riot-id";
+        }
+        else {
+            return null;
+        }
+
+        return CloseableIterators.from(new Iterator<Account>() {
+            @Override
+            public boolean hasNext() {
+                if (puuidsIterator != null) {
+                    return puuidsIterator.hasNext();
+                }
+                return riotIdsIterator.hasNext();
+            }
+
+            @Override
+            public Account next() {
+                if (puuidsIterator != null) {
+                    final String identifier = puuidsIterator.next();
+                    final String endpoint = baseEndpoint + identifier;
+                    final Account data = get(Account.class, endpoint, platform, limiter, true);
+
+                    if (data == null) {
+                        return null;
+                    }
+
+                    data.setPlatform(platform.getTag());
+                    return data;
+                }
+                else {
+                    final Map.Entry<String, String> identifier = riotIdsIterator.next();
+                    final String endpoint = baseEndpoint + identifier.getKey() + "/" + identifier.getValue();
+                    final Account data = get(Account.class, endpoint, platform, limiter, true);
+                    if (data == null) {
+                        return null;
+                    }
+                    data.setPlatform(platform.getTag());
+                    return data;
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        });
+    }
+
+    @Get(Account.class)
+    public Account getAccount(final Map<String, Object> query, final PipelineContext context) {
+        final Platform platform = (Platform) query.get("platform");
+        Utilities.checkNotNull(platform, "platform");
+        final String puuid = (String)query.get("puuid");
+        final String gameName = (String)query.get("gameName");
+        final String tagLine = (String)query.get("tagLine");
+        Utilities.checkAtLeastOneNotNull(puuid, "puuid", gameName, "gameName", tagLine, "tagLine");
+
+        String endpoint;
+        String limiter;
+        if (puuid != null) {
+            endpoint = "riot/account/v1/accounts/by-puuid/" + puuid;
+            limiter = "riot/account/v1/accounts/by-puuid/puuid";
+        }
+        else if (gameName != null && tagLine != null) {
+            endpoint = "riot/account/v1/accounts/by-riot-id/" + gameName + "/" + tagLine;
+            limiter = "riot/account/v1/accounts/by-riot-id/gameName/tagLine";
+        }
+        else {
+            return null;
+        }
+
+        final Account data = get(Account.class, endpoint, platform, limiter, true);
+        if (data == null) {
+            return null;
+        }
+
+        data.setPlatform(platform.getTag());
+        return data;
+    }
+}

--- a/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/transformers/dtodata/AccountTransformer.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/datapipeline/transformers/dtodata/AccountTransformer.java
@@ -1,0 +1,28 @@
+package com.merakianalytics.orianna.datapipeline.transformers.dtodata;
+
+import com.merakianalytics.datapipelines.PipelineContext;
+import com.merakianalytics.datapipelines.transformers.AbstractDataTransformer;
+import com.merakianalytics.datapipelines.transformers.Transform;
+import com.merakianalytics.orianna.types.data.account.Account;
+
+public class AccountTransformer extends AbstractDataTransformer {
+    @Transform(from = com.merakianalytics.orianna.types.dto.account.Account.class, to = Account.class)
+    public Account transformer(final com.merakianalytics.orianna.types.dto.account.Account item, final PipelineContext context) {
+        final Account account = new Account();
+        account.setGameName(item.getGameName());
+        account.setTagLine(item.getTagLine());
+        account.setPlatform(item.getPlatform());
+        account.setPuuid(item.getPuuid());
+        return account;
+    }
+
+    @Transform(from = Account.class, to = com.merakianalytics.orianna.types.dto.account.Account.class)
+    public com.merakianalytics.orianna.types.dto.account.Account transformer(final Account item, final PipelineContext context) {
+        final com.merakianalytics.orianna.types.dto.account.Account account = new com.merakianalytics.orianna.types.dto.account.Account();
+        account.setGameName(item.getGameName());
+        account.setTagLine(item.getTagLine());
+        account.setPlatform(item.getPlatform());
+        account.setPuuid(item.getPuuid());
+        return account;
+    }
+}

--- a/orianna/src/main/java/com/merakianalytics/orianna/types/UniqueKeys.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/types/UniqueKeys.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableSet;
 import com.merakianalytics.orianna.types.common.Platform;
 import com.merakianalytics.orianna.types.common.Queue;
 import com.merakianalytics.orianna.types.common.Tier;
+import com.merakianalytics.orianna.types.core.account.Account;
 import com.merakianalytics.orianna.types.core.champion.ChampionRotation;
 import com.merakianalytics.orianna.types.core.championmastery.ChampionMasteries;
 import com.merakianalytics.orianna.types.core.championmastery.ChampionMastery;
@@ -4284,6 +4285,34 @@ public abstract class UniqueKeys {
         return Arrays.hashCode(new Object[] {
             ShardStatus.class.getCanonicalName(), ((Platform)query.get("platform")).getTag()
         });
+    }
+
+    public static int[] forAccount(final Account account) {
+        final com.merakianalytics.orianna.types.data.account.Account data = account.getCoreData();
+        int count = 0;
+
+        if (data.getPuuid() != null) {
+            count++;
+        }
+        if (data.getTagLine() != null && data.getGameName() != null) {
+            count++;
+        }
+
+        final int[] keys = new int[count];
+        count = 0;
+
+        if (data.getPuuid() != null) {
+            keys[count++] = Arrays.hashCode(new Object[] {
+                    Account.class.getCanonicalName(), data.getPlatform(), data.getPuuid()
+            });
+        }
+        if (data.getTagLine() != null && data.getGameName() != null) {
+            keys[count++] = Arrays.hashCode(new Object[] {
+                    Account.class.getCanonicalName(), data.getPlatform(), data.getTagLine(), data.getGameName()
+            });
+        }
+
+        return keys;
     }
 
     public static int[] forSummoner(final Summoner summoner) {

--- a/orianna/src/main/java/com/merakianalytics/orianna/types/common/Platform.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/types/common/Platform.java
@@ -9,22 +9,22 @@ import com.merakianalytics.orianna.types.core.staticdata.Versions;
 import com.merakianalytics.orianna.types.core.status.ShardStatus;
 
 public enum Platform {
-        BRAZIL("BR1", "pt_BR"),
-        EUROPE_NORTH_EAST("EUN1", "en_GB"),
-        EUROPE_WEST("EUW1", "en_GB"),
-        JAPAN("JP1", "ja_JP"),
-        KOREA("KR", "ko_KR"),
-        LATIN_AMERICA_NORTH("LA1", "es_MX"),
-        LATIN_AMERICA_SOUTH("LA2", "es_AR"),
-        NORTH_AMERICA("NA1", "en_US"),
-        OCEANIA("OC1", "en_AU"),
-        RUSSIA("RU", "ru_RU"),
-        TURKEY("TR1", "tr_TR"),
-        PHILIPPINES("PH2", "en_PH"),
-        SINGAPORE("SG2", "en_SG"),
-        THAILAND("TH2", "th_TH"),
-        TAIWAN("TW2", "zh_TW"),
-        VIETNAM("VN2", "vn_VN");
+    BRAZIL("BR1", "pt_BR", "AMERICAS"),
+    EUROPE_NORTH_EAST("EUN1", "en_GB", "EUROPE"),
+    EUROPE_WEST("EUW1", "en_GB", "EUROPE"),
+    JAPAN("JP1", "ja_JP", "ASIA"),
+    KOREA("KR", "ko_KR", "ASIA"),
+    LATIN_AMERICA_NORTH("LA1", "es_MX", "AMERICAS"),
+    LATIN_AMERICA_SOUTH("LA2", "es_AR", "AMERICAS"),
+    NORTH_AMERICA("NA1", "en_US", "AMERICAS"),
+    OCEANIA("OC1", "en_AU", "SEA"),
+    RUSSIA("RU", "ru_RU", "EUROPE"),
+    TURKEY("TR1", "tr_TR", "EUROPE"),
+    PHILIPPINES("PH2", "en_PH", "SEA"),
+    SINGAPORE("SG2", "en_SG", "SEA"),
+    THAILAND("TH2", "th_TH", "SEA"),
+    TAIWAN("TW2", "zh_TW", "SEA"),
+    VIETNAM("VN2", "vn_VN", "SEA");
 
     private static final java.util.Map<String, Platform> BY_TAG = getByTag();
 
@@ -42,10 +42,12 @@ public enum Platform {
 
     private final String defaultLocale;
     private final String tag;
+    private final String regionalRoute;
 
-    private Platform(final String tag, final String defaultLocale) {
+    private Platform(final String tag, final String defaultLocale, String regionalRoute) {
         this.tag = tag;
         this.defaultLocale = defaultLocale;
+        this.regionalRoute = regionalRoute;
     }
 
     public String getDefaultLocale() {
@@ -79,4 +81,6 @@ public enum Platform {
     public Versions getVersions() {
         return Versions.withPlatform(this).get();
     }
+
+    public String getRegionalRoute() { return regionalRoute; }
 }

--- a/orianna/src/main/java/com/merakianalytics/orianna/types/core/account/Account.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/types/core/account/Account.java
@@ -1,0 +1,143 @@
+package com.merakianalytics.orianna.types.core.account;
+
+import com.google.common.collect.ImmutableMap;
+import com.merakianalytics.orianna.Orianna;
+import com.merakianalytics.orianna.types.common.Platform;
+import com.merakianalytics.orianna.types.common.Region;
+import com.merakianalytics.orianna.types.core.GhostObject;
+import com.merakianalytics.orianna.types.core.searchable.Searchable;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class Account extends GhostObject<com.merakianalytics.orianna.types.data.account.Account> {
+    public static class Builder {
+        private enum KeyType {
+            RIOT_ID,
+            PUUID
+        }
+        private Platform platform;
+        private String gameName, tagLine, puuid;
+
+        private Builder(final String gameName, final String tagLine) {
+            this.gameName = gameName;
+            this.tagLine = tagLine;
+        }
+        private Builder(final String puuid) {
+            this.puuid = puuid;
+        }
+
+        public Account get() {
+            if (puuid == null && (gameName == null && tagLine == null)) {
+                throw new IllegalStateException("Must set a puuid, or a game name and a tag line for the Account!");
+            }
+
+            if (platform == null) {
+                platform = Orianna.getSettings().getDefaultPlatform();
+                if (platform == null) {
+                    throw new IllegalStateException(
+                            "No platform/region was set! Must either set a default platform/region with Orianna.setDefaultPlatform or Orianna.setDefaultRegion, or include a platform/region with the request!");
+                }
+            }
+
+            final ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object> builder().put("platform", platform);
+
+            if (puuid != null) {
+                builder.put("puuid", puuid);
+            }
+            else {
+                builder.put("gameName", gameName);
+                builder.put("tagLine", tagLine);
+            }
+
+            System.out.println(gameName + tagLine + puuid);
+            return Orianna.getSettings().getPipeline().get(Account.class, builder.build());
+        }
+
+        public Account.Builder withPlatform(final Platform platform) {
+            this.platform = platform;
+            return this;
+        }
+
+        public Account.Builder withRegion(final Region region) {
+            platform = region.getPlatform();
+            return this;
+        }
+    }
+
+    public static final String ACCOUNT_LOAD_GROUP = "account";
+
+    public static Account.Builder withRiotId(final String gameName, final String tagLine) {
+        return new Account.Builder(gameName, tagLine);
+    }
+    public static Account.Builder withPuuid(final String puuid) {
+        return new Account.Builder(puuid);
+    }
+
+    public Account(final com.merakianalytics.orianna.types.data.account.Account coreData) {
+        super (coreData, 1);
+    }
+
+    @Override
+    public boolean exists() {
+        if(coreData.getPuuid() == null) {
+            load(ACCOUNT_LOAD_GROUP);
+        }
+        return coreData.getPuuid() != null;
+    }
+
+    @Override
+    protected List<String> getLoadGroups() {
+        return Arrays.asList(new String[] {
+                ACCOUNT_LOAD_GROUP
+        });
+    }
+
+    @Override
+    protected void loadCoreData(String group) {
+        ImmutableMap.Builder<String, Object> builder;
+        switch (group) {
+            case ACCOUNT_LOAD_GROUP:
+                builder = ImmutableMap.builder();
+                if (coreData.getPuuid() != null) {
+                    builder.put("puuid", coreData.getPuuid());
+                }
+                if (coreData.getGameName() != null) {
+                    builder.put("gameName", coreData.getGameName());
+                }
+                if (coreData.getTagLine() != null) {
+                    builder.put("tagLine", coreData.getTagLine());
+                }
+                if (coreData.getPlatform() != null) {
+                    builder.put("platform", Platform.withTag(coreData.getPlatform()));
+                }
+                final com.merakianalytics.orianna.types.data.account.Account data =
+                        Orianna.getSettings().getPipeline().get(
+                                com.merakianalytics.orianna.types.data.account.Account.class, builder.build()
+                        );
+
+                if (data != null) {
+                    coreData = data;
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Searchable(String.class)
+    public String getPuuid() {
+        if(coreData.getPuuid() == null) {
+            load(ACCOUNT_LOAD_GROUP);
+        }
+        return coreData.getPuuid();
+    }
+
+    public Platform getPlatform() {
+        return Platform.withTag(coreData.getPlatform());
+    }
+
+    public Region getRegion() {
+        return Platform.withTag(coreData.getPlatform()).getRegion();
+    }
+}

--- a/orianna/src/main/java/com/merakianalytics/orianna/types/core/account/Account.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/types/core/account/Account.java
@@ -50,7 +50,6 @@ public class Account extends GhostObject<com.merakianalytics.orianna.types.data.
                 builder.put("tagLine", tagLine);
             }
 
-            System.out.println(gameName + tagLine + puuid);
             return Orianna.getSettings().getPipeline().get(Account.class, builder.build());
         }
 

--- a/orianna/src/main/java/com/merakianalytics/orianna/types/core/account/Account.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/types/core/account/Account.java
@@ -28,7 +28,7 @@ public class Account extends GhostObject<com.merakianalytics.orianna.types.data.
         }
 
         public Account get() {
-            if (puuid == null && (gameName == null && tagLine == null)) {
+            if (puuid == null && (gameName == null || tagLine == null)) {
                 throw new IllegalStateException("Must set a puuid, or a game name and a tag line for the Account!");
             }
 

--- a/orianna/src/main/java/com/merakianalytics/orianna/types/core/account/Accounts.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/types/core/account/Accounts.java
@@ -1,0 +1,84 @@
+package com.merakianalytics.orianna.types.core.account;
+
+import com.google.common.collect.ImmutableMap;
+import com.merakianalytics.datapipelines.iterators.CloseableIterator;
+import com.merakianalytics.datapipelines.iterators.CloseableIterators;
+import com.merakianalytics.orianna.Orianna;
+import com.merakianalytics.orianna.types.common.Platform;
+import com.merakianalytics.orianna.types.common.Region;
+import com.merakianalytics.orianna.types.core.searchable.SearchableList;
+import com.merakianalytics.orianna.types.core.searchable.SearchableLists;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public abstract class Accounts {
+    public static class Builder {
+        private enum KeyType {
+            RIOT_ID,
+            PUUID
+        }
+        private Platform platform;
+        private Iterable<String> puuids;
+        private Iterable<Map.Entry<String, String>> riotIds;
+        private boolean streaming = false;
+
+        private Builder(final List<Map.Entry<String, String>> keys) {
+            riotIds = new Iterable<Map.Entry<String, String>>() {
+                @Override
+                public Iterator<Map.Entry<String, String>> iterator() {
+                    return keys.iterator();
+                }
+            };
+        }
+        private Builder(final Iterable<String> keys) {
+            this.puuids = keys;
+        }
+
+        public SearchableList<Account> get() {
+            if (puuids == null && riotIds == null) {
+                throw new IllegalStateException("Must set a puuid, or a game name and a tag line for the Accounts!");
+            }
+
+            if (platform == null) {
+                platform = Orianna.getSettings().getDefaultPlatform();
+                if (platform == null) {
+                    throw new IllegalStateException(
+                            "No platform/region was set! Must either set a default platform/region with Orianna.setDefaultPlatform or Orianna.setDefaultRegion, or include a platform/region with the request!");
+                }
+            }
+
+            final ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object> builder().put("platform", platform);
+
+            if (puuids != null) {
+                builder.put("puuids", puuids);
+            }
+            else {
+                builder.put("riotIds", riotIds);
+            }
+
+            final CloseableIterator<Account> result = Orianna.getSettings().getPipeline().getMany(Account.class, builder.build(), streaming);
+            return streaming ? SearchableLists.from(CloseableIterators.toLazyList(result)) : SearchableLists.from(CloseableIterators.toList(result));
+
+        }
+
+        public Builder withPlatform(final Platform platform) {
+            this.platform = platform;
+            return this;
+        }
+
+        public Builder withRegion(final Region region) {
+            platform = region.getPlatform();
+            return this;
+        }
+    }
+
+    public static Builder withRiotIds(final List<Map.Entry<String, String>> riotIds) {
+        return new Builder(riotIds);
+    }
+    public static Builder withPuuids(final String... puuids) {
+        return new Builder(Arrays.asList(puuids));
+    }
+}

--- a/orianna/src/main/java/com/merakianalytics/orianna/types/data/account/Account.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/types/data/account/Account.java
@@ -1,0 +1,67 @@
+package com.merakianalytics.orianna.types.data.account;
+
+import com.merakianalytics.orianna.types.data.CoreData;
+
+public class Account extends CoreData {
+    private String gameName, tagLne, puuid, platform;
+
+    /**
+     * @return the game name
+     */
+    public String getGameName() {
+        return gameName;
+    }
+
+    /**
+     * @return the tag line
+     */
+    public String getTagLine() {
+        return tagLne;
+    }
+
+    /**
+     * @return the puuid
+     */
+    public String getPuuid() {
+        return puuid;
+    }
+
+    /**
+     * @return the platform
+     */
+    public String getPlatform() {
+        return platform;
+    }
+
+    /**
+     * @param tagLne
+     *        the tagline to set
+     */
+    public void setTagLine(String tagLne) {
+        this.tagLne = tagLne;
+    }
+
+    /**
+     * @param gameName
+     *        the game name to set
+     */
+    public void setGameName(String gameName) {
+        this.gameName = gameName;
+    }
+
+    /**
+     * @param puuid
+     *        the puuid to set
+     */
+    public void setPuuid(String puuid) {
+        this.puuid = puuid;
+    }
+
+    /**
+     * @param platform
+     *        the platform to set
+     */
+    public void setPlatform(final String platform) {
+        this.platform = platform;
+    }
+}

--- a/orianna/src/main/java/com/merakianalytics/orianna/types/dto/account/Account.java
+++ b/orianna/src/main/java/com/merakianalytics/orianna/types/dto/account/Account.java
@@ -1,0 +1,68 @@
+package com.merakianalytics.orianna.types.dto.account;
+
+import com.merakianalytics.orianna.types.dto.DataObject;
+
+public class Account extends DataObject {
+    private String gameName, tagLne, puuid, platform;
+
+    /**
+     * @return the game name
+     */
+    public String getGameName() {
+        return gameName;
+    }
+
+    /**
+     * @return the tag line
+     */
+    public String getTagLine() {
+        return tagLne;
+    }
+
+    /**
+     * @return the puuid
+     */
+    public String getPuuid() {
+        return puuid;
+    }
+
+    /**
+     * @return the platform
+     */
+    public String getPlatform() {
+        return platform;
+    }
+
+    /**
+     * @param tagLne
+     *        the tagline to set
+     */
+
+    public void setTagLine(String tagLne) {
+        this.tagLne = tagLne;
+    }
+
+    /**
+     * @param gameName
+     *        the game name to set
+     */
+    public void setGameName(String gameName) {
+        this.gameName = gameName;
+    }
+
+    /**
+     * @param puuid
+     *        the puuid to set
+     */
+    public void setPuuid(String puuid) {
+        this.puuid = puuid;
+    }
+
+    /**
+     * @param platform
+     *        the platform to set
+     */
+    public void setPlatform(final String platform) {
+        this.platform = platform;
+    }
+}

--- a/orianna/src/main/resources/com/merakianalytics/orianna/default-orianna-config.json
+++ b/orianna/src/main/resources/com/merakianalytics/orianna/default-orianna-config.json
@@ -9,6 +9,10 @@
         "className": "com.merakianalytics.orianna.datapipeline.InMemoryCache",
         "config": {
           "expirationPeriods": {
+            "com.merakianalytics.orianna.types.core.account.Account": {
+              "period": 1,
+              "unit": "HOURS"
+            },
             "com.merakianalytics.orianna.types.core.champion.ChampionRotation": {
               "period": 6,
               "unit": "HOURS"
@@ -273,6 +277,7 @@
             "https": true
           },
           "services": [
+            "com.merakianalytics.orianna.datapipeline.riotapi.AccountAPI",
             "com.merakianalytics.orianna.datapipeline.riotapi.ChampionAPI",
             "com.merakianalytics.orianna.datapipeline.riotapi.ChampionMasteryAPI",
             "com.merakianalytics.orianna.datapipeline.riotapi.LeagueAPI",
@@ -290,6 +295,9 @@
       }
     ],
     "transformers": [
+      {
+        "className": "com.merakianalytics.orianna.datapipeline.transformers.dtodata.AccountTransformer"
+      },
       {
         "className": "com.merakianalytics.orianna.datapipeline.transformers.dtodata.ChampionMasteryTransformer"
       },


### PR DESCRIPTION
Hi there!

I wanted to use Orianna for a small personal project but while I was using it, I noticed there was no way to query Account-V1. I checked the discord for any information on the topic but couldn't find any, and it was pretty quiet.

Riot will be moving away from Summoner names on Nov 20, according to their API docs. Looks like they will support the Summoner-V4 endpoints for awhile after, but they're deprecated at this point. https://developer.riotgames.com/docs/lol#summoner-names-to-riot-ids_summoner-names-post-migration

I was really unfamiliar with the Orianna repo but I got it working as I needed for my personal project. This pull request includes:

- Adding Account object and related pipeline information to query the Account-V1 API
- Addition of `regionalRoute` to the Platform enum to account for the different endpoint that Account-V1 uses
- New constructors to support the previous change
- 4 new methods in Orianna base class
  - accountWithPuuid
  - accountsWithPuuid
  - accountWithRiotId
  - accountWithRiotId

I realize this is nowhere near a complete PR but it's working enough for my personal project for now, with no breaking changes to the existing codebase to my knowledge. I figured I'd open it since this seems to be something that will be needed in the future anyway, and if anyone wants to use some of the work here it's here to use. I figure this might need a more comprehensive implementation.

There are some questionable decisions (especially in the APIs) that I made because I don't think the pattern of Riot Ids `gameName` and `tagLine` fit in with any existing design patterns. I just wanted to get something working in an afternoon.